### PR TITLE
Improve performance

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,14 @@ function gulpMailgun(mailgunText) {
 
   // Creating a stream through which each file will pass
   var stream = through.obj(function(file, enc, callback) {
-    var mail, raw;
+    var mail, raw, subject;
+
+    subject = _opts.subject;
+    
+    if (subject == null) {
+      subject = file.path.replace(file.cwd + '/dist/', '');
+    }
+
     if (file.isNull()) {
        // Do nothing if no contents
       _opts.body = '';
@@ -38,18 +45,18 @@ function gulpMailgun(mailgunText) {
     }
 
     if (file.isStream()) {
-      // file.contents = file.contents.pipe(mailgunStream(mailgunText));
       _opts.body = file.contents;
     }
     mail = new Mailgun(_opts.key);
+    
+    raw = "From: " + _opts.sender + "\nTo: " + _opts.recipient + "\nContent-Type: text/html; charset=utf-8\nSubject: " + subject + "\n\n " + _opts.body;
 
-    raw = "From: " + _opts.sender + "\nTo: " + _opts.recipient + "\nContent-Type: text/html; charset=utf-8\nSubject: " + _opts.subject + "\n\n " + _opts.body;
     mail.sendRaw(_opts.sender, _opts.recipient, raw, function(err) {
       if (err) {
         console.log('Please make sure you have entered your Mailgun API Key in your gulpfile');
         throw new PluginError(PLUGIN_NAME, 'Error: ' + err);
       } else {
-        console.log('Sent email to ' + _opts.recipient);
+        console.log('Sent file ' + file.path.replace(file.cwd + '/dist/', '') + ' to ' + _opts.recipient);
       }
     });
 

--- a/index.js
+++ b/index.js
@@ -60,7 +60,6 @@ function gulpMailgun(mailgunText) {
       }
     });
 
-    this.push(file);
     return callback();
 
   });


### PR DESCRIPTION
This PR improve performance mainly. 
- the `this.push(file)` is going to queue it up and unless you have a stream on the other end of it it'll just buffer and then stop when it reaches 16. 
- the `subject` key in the config json file is optional. If it's not present, the file name becomes subject. This is handy for testing in Litmus. 
- the filename is used by the console to show what file is sending.
